### PR TITLE
Docs (readme): Add common error messages for *nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,22 @@ To list all installed versions of the module available for import:
 ```powershell
 Get-Module -Name Compile-SourceScript -ListAvailable -Verbose
 ```
+
+## FAQ
+
+### Common issues
+
+- `bash: /path/to/scripting/amxxpc: No such file or directory`
+
+    Install [dependencies](test/scripts/dep/linux/sourcepawn-dependencies.sh) for the compiler.
+
+- `compiler failed to instantiate: amxxpc32.so: cannot open shared object file: No such file or directory`
+
+    Invoke the compiler from within the directory where the compiler is located.
+
+    ```sh
+    cd /path/to/scripting
+    ./amxxpc
+    ```
+
+    See [here](https://forums.alliedmods.net/showthread.php?p=154320) for more details.


### PR DESCRIPTION
Closes #8

It is common for new or inexperienced developers to face some very common errors when using the module or the compilers (`amxxpc` or `spcomp`). However the error messages are generally obscure and developers might not be able to easily find a solution.

Hence, documentation about these errors and their resolution is added in readme. 