### PR TITLE
Refactor (ci): Use `build-test.yml` and `build-publish.yml` entrypoints from `PSModulePublisher` `v0.5.0`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: templates/azure-pipelines/entrypoint/windows/continuous-build.yml@PSModulePublisher
+    - template: templates/azure-pipelines/entrypoint/windows/build-test.yml@PSModulePublisher
   - job: linux_container
     displayName: '[Linux] [Container] PowerShell'
     pool:
@@ -50,7 +50,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: templates/azure-pipelines/entrypoint/linux/continuous-build.yml@PSModulePublisher
+    - template: templates/azure-pipelines/entrypoint/linux/build-test.yml@PSModulePublisher
   - job: windows_powershell_5_1
     displayName: '[Windows] PowerShell 5.1'
     pool:
@@ -58,9 +58,9 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: templates/azure-pipelines/entrypoint/windows/powershell/continuous-build.yml@PSModulePublisher
-- stage: publish
-  displayName: Publish
+    - template: templates/azure-pipelines/entrypoint/windows/powershell/build-test.yml@PSModulePublisher
+- stage: build_publish
+  displayName: Build, Publish
   dependsOn: build_test
   jobs:
   - job: windows_pwsh
@@ -70,11 +70,10 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: templates/azure-pipelines/entrypoint/windows/continuous-build.yml@PSModulePublisher
-    - template: templates/azure-pipelines/entrypoint/windows/publish.yml@PSModulePublisher
+    - template: templates/azure-pipelines/entrypoint/windows/build-publish.yml@PSModulePublisher
 - stage: release
   displayName: Release
-  dependsOn: publish
+  dependsOn: build_publish
   jobs:
   - job: linux_container
     displayName: '[Linux] [Container] PowerShell Core'


### PR DESCRIPTION
`build-test.yml` replaces `continuous-build.yml`, and with `build-publish.yml`, `test` steps are now skipped when publishing the module.